### PR TITLE
Fix spec for content given to generate

### DIFF
--- a/lib/pdf_generator.ex
+++ b/lib/pdf_generator.ex
@@ -116,7 +116,7 @@ defmodule PdfGenerator do
   @type url           :: binary()
   @type html          :: binary()
   @type pdf_file_path :: binary()
-  @type content       :: html | {:url, binary()} | {:ok, url}
+  @type content       :: html | {:url, url} | {:html, html}
   @type reason        :: atom() | {atom(), any}
   @type opts          :: keyword()
   @type path          :: binary()


### PR DESCRIPTION
The generate function accepts three types as content to be processed to PDF:

- `{:html, html}` - pass some HTML to be converted. Handy for templates 
- `{:url, url}` convert some HTML fetched from the `url`. Actual fetching is done by wkhtmltopdf or chrome-headless
- `html` - plain binary is a shortcut for `{:html, html`}